### PR TITLE
Only register contextMenus when installing the extension

### DIFF
--- a/tabulator.js
+++ b/tabulator.js
@@ -174,49 +174,49 @@
     });
 
     //#region Context Menus
+    chrome.runtime.onInstalled.addListener(function () {
+     chrome.contextMenus.create({
+         title: 'Tabulator',
+         type: 'normal',
+         id: 'main',
+         contexts: ['page']
+     });
+     chrome.contextMenus.create({
+         title: 'Open Tabulator',
+         type: 'normal',
+         id: 'backgroundPage',
+         contexts: ['page'],
+         parentId: 'main'
+     });
+     chrome.contextMenus.create({
+         type: 'separator',
+         id: 'separator0',
+         contexts: ['page'],
+         parentId: 'main'
+     });
+     chrome.contextMenus.create({
+         title: 'Save all but active',
+         type: 'normal',
+         id: 'saveAllButActive',
+         contexts: ['page'],
+         parentId: 'main'
+     });
+     chrome.contextMenus.create({
+         title: 'Save open tabs',
+         type: 'normal',
+         id: 'saveOpenTabs',
+         contexts: ['page'],
+         parentId: 'main'
+     });
+     chrome.contextMenus.create({
+         title: 'Save active tab',
+         type: 'normal',
+         id: 'saveActiveTab',
+         contexts: ['page'],
+         parentId: 'main'
+     });
 
-    chrome.contextMenus.create({
-        title: 'Tabulator',
-        type: 'normal',
-        id: 'main',
-        contexts: ['page']
-    });
-    chrome.contextMenus.create({
-        title: 'Open Tabulator',
-        type: 'normal',
-        id: 'backgroundPage',
-        contexts: ['page'],
-        parentId: 'main'
-    });
-    chrome.contextMenus.create({
-        type: 'separator',
-        id: 'separator0',
-        contexts: ['page'],
-        parentId: 'main'
-    });
-    chrome.contextMenus.create({
-        title: 'Save all but active',
-        type: 'normal',
-        id: 'saveAllButActive',
-        contexts: ['page'],
-        parentId: 'main'
-    });
-    chrome.contextMenus.create({
-        title: 'Save open tabs',
-        type: 'normal',
-        id: 'saveOpenTabs',
-        contexts: ['page'],
-        parentId: 'main'
-    });
-    chrome.contextMenus.create({
-        title: 'Save active tab',
-        type: 'normal',
-        id: 'saveActiveTab',
-        contexts: ['page'],
-        parentId: 'main'
-    });
-
-    chrome.contextMenus.onClicked.addListener(function(itemData,tab) {
+   chrome.contextMenus.onClicked.addListener(function(itemData,tab) {
         if (itemData.menuItemId === 'test') {
             getTabs(itemData, tab);
         } else if (itemData.menuItemId === 'backgroundPage') {
@@ -231,8 +231,8 @@
             openOptionsPage();
         }
     });
-
-    //#endregion
+   });
+   //#endregion
 
 }());
 //TODO: Add option to save tabs from context menu.


### PR DESCRIPTION
Because the background page is not persistent,
it is opened multiples times (e.g. when clicking
on the page action and opening the saved tabs).

Instead of making the backgroupd page persistent,
which would increase the baseline footprint
of the extension, this CL moves the context menu
initialization to chrome.runtime.onInstalled as
shown in the Context Menu examples:
https://developer.chrome.com/extensions/samples#search:contextmenus

This removes the following runtime errors seen
in the developer console:

Unchecked runtime.lastError while running contextMenus.create:
Cannot create item with duplicate id <...>