### PR TITLE
Remove empty tab groups

### DIFF
--- a/tabulator-ui.js
+++ b/tabulator-ui.js
@@ -42,10 +42,14 @@
 				};
 
 				vm.rmTab = function (i, ii) {
-					// remove from view array
-					//vm.list[i].tabs().splice(ii, 1);
 					// remove from localStorage
 					tabGroups[i].tabs.splice(ii, 1);
+					// Remove the group if empty.
+					if (tabGroups[i].tabs.length === 0) {
+						vm.rmGroup(i);
+						// We fall-through here even if rmGroup
+						// already saves the tab groups.
+					}
 					// save
 					saveTabGroups(tabGroups);
 				};


### PR DESCRIPTION
This CL automatically removes tab
groups without any tabs under them.

As those are not useful to the
user, this wasn't set as an option.

Note that this CL intentionally doesn't
filter them when loading the tabGroups.
This is because a linear search when
starting the extension would penalize
users with a lot of saved tabs. They
will catch up over time due to the new
behavior (and manually should they wish).

TEST=Manually checked that it works when removing a tab, restoring one or all tabs